### PR TITLE
devops: add CI env variable and --watchAll=false 

### DIFF
--- a/services/client/package.json
+++ b/services/client/package.json
@@ -31,9 +31,9 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "CI=true react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
-    "coverage": "CI=true react-scripts test --coverage"
+    "coverage": "CI=true react-scripts test --watchAll=false"
   },
   "browserslist": {
     "production": [

--- a/test-ci.sh
+++ b/test-ci.sh
@@ -17,7 +17,7 @@ dev() {
   inspect $? users
   docker-compose exec users flake8 project
   inspect $? users-lint
-  docker-compose exec client npm test -- --watchAll=false
+  docker-compose exec client npm test
   inspect $? client
   docker-compose down
 }

--- a/test.sh
+++ b/test.sh
@@ -44,7 +44,7 @@ all() {
   inspect $? users
   docker-compose exec users flake8 project
   inspect $? users-lint
-  docker-compose exec client npm test -- --coverage
+  docker-compose exec client npm test
   inspect $? client
   docker-compose down
   e2e


### PR DESCRIPTION
add CI env and --watchAll=false to avoid enzyme hanging during client test runs on travis